### PR TITLE
Add gated `serial` module, configure `FILE` as serial device on `--freq`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,8 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: cargo test --all
+      - name: cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --all-features --all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+- `itm`: `serial` convenience module for serial device configuration. Gated behind a `"serial"` feature.
+
+### Changed
+- `itm-decode`: configures the given file as a serial device on `--freq`.
+
 ## [v0.7.0] - 2022-01-17
 
 This large bump in minor is required to break the API of both `itm` v0.3.1 and `itm-decode` v0.6.1, which this crate replaces.
@@ -89,7 +97,8 @@ Related topics: https://github.com/rust-embedded/itm/pull/41, https://github.com
 - `itmdump` tool that parses instrumentation packets from the stimulus port 0
   and dumps the payload to `stdout`.
 
-[Unreleased]: https://github.com/rtic-scope/itm/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/rtic-scope/itm/compare/v0.7.0...HEAD
+[v0.7.0]: https://github.com/rtic-scope/itm/compare/v0.4.0...v0.7.0
 [v0.4.0]: https://github.com/rtic-scope/itm/compare/v0.3.0...v0.4.0
 [v0.3.0]: https://github.com/rtic-scope/itm/compare/v0.2.1...v0.3.0
 [v0.2.1]: https://github.com/rtic-scope/itm/compare/v0.2.0...v0.2.1

--- a/itm-decode/Cargo.toml
+++ b/itm-decode/Cargo.toml
@@ -13,6 +13,6 @@ license = "MIT OR Apache-2.0"
 description = "A decoding tool for the ARM Cortex-M ITM/DWT packet protocol"
 
 [dependencies]
-itm = { version = "0.7.0", path = "../itm" }
+itm = { version = "0.7.0", path = "../itm", features = [ "serial" ] }
 anyhow = "1.0"
 structopt = "0.3"

--- a/itm-decode/src/main.rs
+++ b/itm-decode/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Context, Result};
-use itm::{Decoder, DecoderOptions, LocalTimestampOptions, TimestampsConfiguration};
+use itm::{serial, Decoder, DecoderOptions, LocalTimestampOptions, TimestampsConfiguration};
 use std::fs::File;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -32,6 +32,10 @@ fn main() -> Result<()> {
     let opt = Opt::from_args();
 
     let file = File::open(&opt.file).context("failed to open file")?;
+    if let Some(freq) = opt.freq {
+        serial::configure(&file, freq)?;
+    }
+
     let decoder = Decoder::<File>::new(
         file,
         DecoderOptions {

--- a/itm/Cargo.toml
+++ b/itm/Cargo.toml
@@ -22,8 +22,18 @@ version = "1"
 features = [ "derive" ]
 optional = true
 
+[dependencies.nix]
+version = "0.23"
+git = "https://github.com/rtic-scope/nix.git"
+branch = "feat/termios-linux-arbitrary"
+optional = true
+
 [dependencies.cortex-m]
 version = "0.7"
 git = "https://github.com/rtic-scope/cortex-m"
 branch = "rtic-scope"
 features = ["serde"]
+
+[features]
+default = []
+serial = ["nix"]

--- a/itm/src/lib.rs
+++ b/itm/src/lib.rs
@@ -38,6 +38,9 @@ pub use iter::{
     TimestampsConfiguration,
 };
 
+#[cfg(feature = "serial")]
+pub mod serial;
+
 use std::convert::TryInto;
 use std::io::Read;
 

--- a/itm/src/serial.rs
+++ b/itm/src/serial.rs
@@ -1,0 +1,214 @@
+//! Convenience module for serial device configuration.
+//!
+//! This module exposes a single function, [`configure`], used to
+//! configure a serial device with a wanted baud rate so that the device
+//! can be used with this crate. This functionality is used downstream
+//! in `itm-decode` and `cargo-rtic-scope`.
+
+use nix::{
+    fcntl::{self, FcntlArg, OFlag},
+    libc,
+    sys::termios::{
+        self, ArbitraryBaudRate, BaudRate, ControlFlags, InputFlags, LocalFlags, OutputFlags,
+        SetArg, SpecialCharacterIndices as CC,
+    },
+};
+use std::fs;
+use std::os::unix::io::AsRawFd;
+use thiserror::Error;
+
+mod ioctl {
+    use super::libc;
+    use nix::{ioctl_none_bad, ioctl_read_bad, ioctl_write_int_bad, ioctl_write_ptr_bad};
+
+    ioctl_none_bad!(tiocexcl, libc::TIOCEXCL);
+    ioctl_read_bad!(tiocmget, libc::TIOCMGET, libc::c_int);
+    ioctl_read_bad!(fionread, libc::FIONREAD, libc::c_int);
+    ioctl_write_ptr_bad!(tiocmset, libc::TIOCMSET, libc::c_int);
+    ioctl_write_int_bad!(tcflsh, libc::TCFLSH);
+}
+
+/// Possible errors on [`configure`].
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum SerialError {
+    #[error("Error configuring serial device: {0}")]
+    General(String),
+}
+
+/// Opens and configures the given `device`.
+///
+/// Effectively mirrors the behavior of
+/// ```shell,ignore
+/// $ screen <device> <baud rate>
+/// ```
+///
+/// TODO ensure POSIX compliance, see termios(3)
+/// TODO We are currently using line disciple 0. Is that correct?
+pub fn configure(device: &fs::File, baud_rate: u32) -> Result<(), SerialError> {
+    use SerialError as Error;
+
+    // ensure a valid baud rate was requested
+    let baud_rate: BaudRate = ArbitraryBaudRate(baud_rate)
+        .try_into()
+        .map_err(|_| Error::General(format!("{} is not a valid baud rate", baud_rate)))?;
+    if baud_rate == BaudRate::B0 {
+        return Err(Error::General("baud rate cannot be 0".to_string()));
+    }
+
+    unsafe {
+        let fd = device.as_raw_fd();
+
+        // Enable exclusive mode. Any further open(2) will fail with EBUSY.
+        ioctl::tiocexcl(fd).map_err(|e| {
+            Error::General(format!(
+                "Failed to put device into exclusive mode: tiocexcl = {}",
+                e
+            ))
+        })?;
+
+        let mut settings = termios::tcgetattr(fd).map_err(|e| {
+            Error::General(format!(
+                "Failed to read terminal settings of device: tcgetattr = {}",
+                e
+            ))
+        })?;
+
+        settings.input_flags |= InputFlags::BRKINT | InputFlags::IGNPAR | InputFlags::IXON;
+        settings.input_flags &= !(InputFlags::ICRNL
+            | InputFlags::IGNBRK
+            | InputFlags::PARMRK
+            | InputFlags::INPCK
+            | InputFlags::ISTRIP
+            | InputFlags::INLCR
+            | InputFlags::IGNCR
+            | InputFlags::ICRNL
+            | InputFlags::IXOFF
+            | InputFlags::IXANY
+            | InputFlags::IMAXBEL
+            | InputFlags::IUTF8);
+
+        settings.output_flags |= OutputFlags::NL0
+            | OutputFlags::CR0
+            | OutputFlags::TAB0
+            | OutputFlags::BS0
+            | OutputFlags::VT0
+            | OutputFlags::FF0;
+        settings.output_flags &= !(OutputFlags::OPOST
+            | OutputFlags::ONLCR
+            | OutputFlags::OLCUC
+            | OutputFlags::OCRNL
+            | OutputFlags::ONOCR
+            | OutputFlags::ONLRET
+            | OutputFlags::OFILL
+            | OutputFlags::OFDEL
+            | OutputFlags::NL1
+            | OutputFlags::CR1
+            | OutputFlags::CR2
+            | OutputFlags::CR3
+            | OutputFlags::TAB1
+            | OutputFlags::TAB2
+            | OutputFlags::TAB3
+            | OutputFlags::XTABS
+            | OutputFlags::BS1
+            | OutputFlags::VT1
+            | OutputFlags::FF1
+            | OutputFlags::NLDLY
+            | OutputFlags::CRDLY
+            | OutputFlags::TABDLY
+            | OutputFlags::BSDLY
+            | OutputFlags::VTDLY
+            | OutputFlags::FFDLY);
+
+        settings.control_flags |= ControlFlags::CS6
+            | ControlFlags::CS7
+            | ControlFlags::CS8
+            | ControlFlags::CREAD
+            | ControlFlags::CLOCAL
+            | ControlFlags::CBAUDEX // NOTE also via cfsetspeed below
+            | ControlFlags::CSIZE;
+        settings.control_flags &= !(ControlFlags::HUPCL
+            | ControlFlags::CS5
+            | ControlFlags::CSTOPB
+            | ControlFlags::PARENB
+            | ControlFlags::PARODD
+            | ControlFlags::CRTSCTS
+            | ControlFlags::CBAUD // NOTE also set via cfsetspeed below?
+            | ControlFlags::CMSPAR
+            | ControlFlags::CIBAUD);
+
+        settings.local_flags |= LocalFlags::ECHOKE
+            | LocalFlags::ECHOE
+            | LocalFlags::ECHOK
+            | LocalFlags::ECHOCTL
+            | LocalFlags::IEXTEN;
+        settings.local_flags &= !(LocalFlags::ECHO
+            | LocalFlags::ISIG
+            | LocalFlags::ICANON
+            | LocalFlags::ECHONL
+            | LocalFlags::ECHOPRT
+            | LocalFlags::EXTPROC
+            | LocalFlags::TOSTOP
+            | LocalFlags::FLUSHO
+            | LocalFlags::PENDIN
+            | LocalFlags::NOFLSH);
+
+        termios::cfsetspeed(&mut settings, baud_rate).map_err(|e| {
+            Error::General(format!(
+                "Failed to configure device baud rate: cfsetspeed = {}",
+                e
+            ))
+        })?;
+
+        settings.control_chars[CC::VTIME as usize] = 2;
+        settings.control_chars[CC::VMIN as usize] = 100;
+
+        // Drain all output, flush all input, and apply settings.
+        termios::tcsetattr(fd, SetArg::TCSAFLUSH, &settings).map_err(|e| {
+            Error::General(format!(
+                "Failed to apply terminal settings to device: tcsetattr = {}",
+                e
+            ))
+        })?;
+
+        let mut flags: libc::c_int = 0;
+        ioctl::tiocmget(fd, &mut flags).map_err(|e| {
+            Error::General(format!(
+                "Failed to read modem bits of device: tiocmget = {}",
+                e
+            ))
+        })?;
+        flags |= libc::TIOCM_DTR | libc::TIOCM_RTS;
+        ioctl::tiocmset(fd, &flags).map_err(|e| {
+            Error::General(format!(
+                "Failed to apply modem bits to device: tiocmset = {}",
+                e
+            ))
+        })?;
+
+        // Make the tty read-only.
+        fcntl::fcntl(fd, FcntlArg::F_SETFL(OFlag::O_RDONLY)).map_err(|e| {
+            Error::General(format!("Failed to make device read-only: fcntl = {}", e))
+        })?;
+
+        // Flush all pending I/O, just in case.
+        ioctl::tcflsh(fd, libc::TCIOFLUSH).map_err(|e| {
+            Error::General(format!("Failed to flush I/O of device: tcflsh = {}", e))
+        })?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn u32_to_baud_rate() {
+        assert_eq!(
+            Ok(BaudRate::B9600),
+            BaudRate::try_from(ArbitraryBaudRate(9600))
+        );
+    }
+}


### PR DESCRIPTION
This PR adds a gated convenience module that handles serial device configuration so that a it works with `itm`. It is now used in `itm-decode` on `--freq`, and will be used in `cargo-rtic-scope`.