### PR TITLE
Update dependency on bitvec to version 1.0

### DIFF
--- a/itm/Cargo.toml
+++ b/itm/Cargo.toml
@@ -14,7 +14,7 @@ description = "A decoding library for the ARM Cortex-M ITM/DWT packet protocol"
 
 [dependencies]
 bitmatch = "0.1.1"
-bitvec = "0.22"
+bitvec = "1.0"
 thiserror = "1"
 
 [dependencies.serde]

--- a/itm/src/lib.rs
+++ b/itm/src/lib.rs
@@ -435,7 +435,7 @@ where
                     return Err(DecoderErrorInt::Eof);
                 }
                 Ok(n) => {
-                    let mut bv = BitVec::<LocalBits, _>::from_vec(buffer[0..n].to_vec());
+                    let mut bv = BitVec::<_, LocalBits>::from_vec(buffer[0..n].to_vec());
                     bv.reverse();
                     bv.append(&mut self.buffer);
                     self.buffer.append(&mut bv);


### PR DESCRIPTION
Version 0.22 of bitvec currently doesn't compile because it depends on version 1.2 of funty, which was yanked from crates.io.

Upgrading to bitvec 1.0 fixes this, as bitvec 1.0 depends on the current version of funty, 2.0.

Only a minor code change was necessary for the upgrade (type parameter reordering, as described in https://github.com/bitvecto-rs/bitvec/blob/main/CHANGELOG.md#type-parameter-re%C3%B6rdering ).

I don't have a good test case for `itm`, so I only checked that it still compiles and the unit tests run successfully.

As BitVec is not exposed in the API of itm, this shouldn't be a (semver) breaking change.