### PR TITLE
disable IXON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 ### Changed
 ### Fixed
+- Serial configuration should no longer drop byte 0x11 (XON)
 
 ## [v0.8.0] - 2022-11-20
 ### Added

--- a/itm/src/serial.rs
+++ b/itm/src/serial.rs
@@ -74,7 +74,7 @@ pub fn configure(device: &fs::File, baud_rate: u32) -> Result<(), SerialError> {
             ))
         })?;
 
-        settings.input_flags |= InputFlags::BRKINT | InputFlags::IGNPAR | InputFlags::IXON;
+        settings.input_flags |= InputFlags::BRKINT | InputFlags::IGNPAR;
         settings.input_flags &= !(InputFlags::ICRNL
             | InputFlags::IGNBRK
             | InputFlags::PARMRK
@@ -83,6 +83,7 @@ pub fn configure(device: &fs::File, baud_rate: u32) -> Result<(), SerialError> {
             | InputFlags::INLCR
             | InputFlags::IGNCR
             | InputFlags::ICRNL
+            | InputFlags::IXON
             | InputFlags::IXOFF
             | InputFlags::IXANY
             | InputFlags::IMAXBEL


### PR DESCRIPTION
ITM needs the raw byte stream. Enabling IXON deletes bytes before they are handed to userspace. This causes ITM packets to be interpreted incorrectly.